### PR TITLE
Change post type from resource to opportunity.

### DIFF
--- a/page-templates/home.php
+++ b/page-templates/home.php
@@ -147,7 +147,7 @@ get_header();
           <div class="article-block__left-col col-sm-12 col-md-6 col-lg-8">
 
             <!-- Lastest Features - start -->
-            <h3 class="block-head"><span>The Latest Features</span></h3>
+            <h3 class="block-head"><span>In Practice</span></h3>
 
             <div class="row">
               <?php
@@ -184,7 +184,7 @@ get_header();
                 };
                 wp_reset_query();
               ?>
-             <a href="features" class="btn pl-4 pr-4">View all features</a>
+             <a href="features" class="btn pl-4 pr-4">View All</a>
             </div>
             <!-- Latest features - end -->
 
@@ -271,7 +271,7 @@ get_header();
 
             <?php
               $resources_args = array(
-                'post_type'        => 'resource',
+                'post_type'        => 'opportunity',
                 'posts_per_page'   => '12',
                 'orderby'          => 'date',
                 'order'            => 'DESC'
@@ -299,7 +299,7 @@ get_header();
                 };
               };
             ?>
-            <a class="btn" href="resources">View More Resources</a>
+            <a class="btn" href="resources">View More Opportunities</a>
             <!-- Resources block - end -->
 
             <!-- Subscribe form - start -->

--- a/page-templates/resource-category.php
+++ b/page-templates/resource-category.php
@@ -39,7 +39,7 @@ get_header();
         $paged = ( get_query_var('paged') > 1 ) ? get_query_var('paged') : 1;
 
         $args = array(
-          'post_type'           => 'resource',
+          'post_type'           => 'opportunity',
           'meta_query'          => array(
                                       'resource-type' => array(
                                         'key'     => 'resource_type',
@@ -226,11 +226,11 @@ get_header();
       <aside id="secondary" class="widget-area col-sm-12 col-lg-3 mt-5 article-block__right-col" role="complementary">
 
       	<h3 class="mb-3">
-      		Other Recent Resources
+      		Other Opportunities
       	</h3>
       	<?php
       		$resources_args = array(
-      			'post_type'        => 'resource',
+      			'post_type'        => 'opportunity',
       			'post__not_in'		 =>	$exclude_posts,
       			'posts_per_page'   => '12',
       			'orderby'          => 'date',

--- a/page-templates/resources.php
+++ b/page-templates/resources.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template Name: Resources
+ * Template Name: Opportunities
  *
  * @package WP_Bootstrap_Starter
  */
@@ -33,7 +33,7 @@ get_header();
         $paged = ( get_query_var('paged') > 1 ) ? get_query_var('paged') : 1;
 
         $args = array(
-          'post_type'   => 'resource',
+          'post_type'   => 'opportunity',
           'meta_query'          => array(
                                       'resource-type' => array(
                                         'key'     => 'resource_type',
@@ -77,7 +77,7 @@ get_header();
 
             <?php
              $args = array(
-               'post_type'   => 'resource',
+               'post_type'   => 'opportunity',
                'meta_query'          => array(
                                            'resource-type' => array(
                                              'key'     => 'resource_type',
@@ -144,7 +144,7 @@ get_header();
           <div class="row">
             <?php
             $args = array(
-              'post_type'   => 'resource',
+              'post_type'   => 'opportunity',
               'meta_query'          => array(
                                           'resource-type' => array(
                                             'key'     => 'resource_type',
@@ -214,7 +214,7 @@ get_header();
           <div class="row">
             <?php
             $args = array(
-              'post_type'   => 'resource',
+              'post_type'   => 'opportunity',
               'meta_query'          => array(
                                           'resource-type' => array(
                                             'key'     => 'resource_type',
@@ -285,7 +285,7 @@ get_header();
           <div class="row">
             <?php
             $args = array(
-              'post_type'   => 'resource',
+              'post_type'   => 'opportunity',
               'meta_query'          => array(
                                           'resource-type' => array(
                                             'key'     => 'resource_type',

--- a/sidebar-resources.php
+++ b/sidebar-resources.php
@@ -15,11 +15,11 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 <aside id="secondary" class="widget-area col-10 offset-1 col-sm-12 col-lg-3 article-block__right-col mt-5" role="complementary">
 
 	<h3 class="">
-		Most Recent Resources
+		More Opportunities
 	</h3>
 	<?php
 		$resources_args = array(
-			'post_type'        => 'resource',
+			'post_type'        => 'opportunity',
 			//'post__not_in'		 =>	$resources,
 			'posts_per_page'   => '12',
 			'orderby'          => 'date',

--- a/single-opportunity.php
+++ b/single-opportunity.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * The template for displaying all single posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package WP_Bootstrap_Starter
+ */
+
+get_header(); ?>
+
+	<section id="primary" class="content-area col-10 offset-1 col-lg-5 offset-lg-2">
+		<main id="main" class="site-main row" role="main">
+			<?php
+			while ( have_posts() ) {
+				the_post();
+
+			?>
+			<div class="mt-5 single-resource-post">
+
+				<?php
+				// Get field label and value for class name and span content
+				$resource_type_field = get_field_object('resource_type');
+				$resource_type_value = $resource_type_field['value'];
+				?>
+
+				<span class="resource-type <?php echo $resource_type_value ?>"><?php the_field('resource_type'); ?></span>
+
+				<?php the_title('<h1>','</h1>'); ?>
+
+				<h3>
+					<?php
+						echo get_field('due_date') ? 'Due Date: '.date('m-d-Y', strtotime(get_field('due_date')) ).'<br>' : '' ;
+						echo get_field('start_date') ? 'Starts: '.date('m-d-Y', strtotime(get_field('start_date')) ).'<br>' : '';
+						echo get_field('end_date') ? 'Ends: '.date('m-d-Y', strtotime(get_field('end_date')) ) : '';
+					?>
+				</h3>
+				<?php echo the_content(); ?>
+			</div>
+			<?php
+			}
+			?>
+
+		</main><!-- #main -->
+	</section><!-- #primary -->
+
+<?php
+get_sidebar('resources');
+get_footer();


### PR DESCRIPTION
Resources will now be known as opportunities, so the slug and post type name will change. This commit makes this change in various hard-coded labels as well as WP queries.

Once this is deployed, I'll have to change the slug and page names on production to match the new label.