### PR TITLE
Removing google ad tag manager from Profession footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -115,15 +115,6 @@
 
 	})
 </script>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-37482664-5"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'UA-37482664-5');
-</script>
 
 <!-- Mouseflow -->
 <script type="text/javascript">


### PR DESCRIPTION
See https://trac.mla.org/traffic/ticket/11180