### PR TITLE
Fix 'in-practice' link

### DIFF
--- a/page-templates/home.php
+++ b/page-templates/home.php
@@ -184,7 +184,7 @@ get_header();
                 };
                 wp_reset_query();
               ?>
-             <a href="features" class="btn pl-4 pr-4">View All</a>
+             <a href="in-practice" class="btn pl-4 pr-4">View All</a>
             </div>
             <!-- Latest features - end -->
 


### PR DESCRIPTION
This is a simple, one-line fix to change a link on the home page, as the page "Features" is now called "In Practice". This page already exists on production, so once the link is updated, it should work just fine.